### PR TITLE
Add admin approval flow for user access

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { useUser } from "@/firebase";
+import { useFirestore, useUser } from "@/firebase";
+import { useDoc } from "@/firebase/firestore/use-doc";
 import {
   SidebarProvider,
   Sidebar,
@@ -10,6 +11,12 @@ import {
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { Header } from "@/components/layout/Header";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { doc } from "firebase/firestore";
+
+type UserProfile = {
+  approved?: boolean;
+  role?: "admin" | "user" | "pending";
+};
 
 export default function DashboardLayout({
   children,
@@ -19,6 +26,14 @@ export default function DashboardLayout({
   const router = useRouter();
   const pathname = usePathname();
   const { user, isUserLoading } = useUser();
+  const firestore = useFirestore();
+
+  const userDocRef = useMemo(
+    () => (user ? doc(firestore, "users", user.uid) : null),
+    [firestore, user],
+  );
+
+  const { data: userProfile, isLoading: isProfileLoading } = useDoc<UserProfile>(userDocRef);
 
   useEffect(() => {
     if (!isUserLoading && !user) {
@@ -26,17 +41,34 @@ export default function DashboardLayout({
     }
   }, [user, isUserLoading, router]);
 
+  useEffect(() => {
+    if (!isUserLoading && user && !isProfileLoading) {
+      if (!userProfile) {
+        router.replace("/login");
+        return;
+      }
+
+      if (!userProfile.approved) {
+        router.replace("/pending-approval");
+      }
+    }
+  }, [isUserLoading, user, isProfileLoading, userProfile, router]);
+
   // Exclude the main dashboard layout from the fullscreen knowledge toolkit pages
   if (pathname.startsWith('/dashboard/knowledge-toolkit')) {
     return <>{children}</>;
   }
-  
-  if (isUserLoading || !user) {
+
+  if (isUserLoading || isProfileLoading || !user || !userProfile) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-background">
         <LoadingSpinner size={48} />
       </div>
     );
+  }
+
+  if (!userProfile.approved) {
+    return null;
   }
 
   return (

--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/firebase";
+
+export default function PendingApprovalPage() {
+  const auth = useAuth();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await auth.signOut();
+    router.push("/login");
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background via-background to-muted px-4 text-center">
+      <div className="max-w-lg space-y-6 rounded-xl border border-border bg-card/70 p-8 shadow-lg backdrop-blur">
+        <h1 className="font-headline text-3xl font-bold text-primary">Cuenta pendiente de aprobación</h1>
+        <p className="text-muted-foreground">
+          Gracias por registrarte en <span className="font-semibold text-foreground">SAP Intelligent Agent</span>. Tu cuenta se encuentra en proceso de revisión.
+          Recibirás acceso en cuanto un administrador autorice tu solicitud.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Si necesitas acceso urgente, comunícate con tu administrador e indícale el correo con el que te registraste.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-center">
+          <Button onClick={() => router.push("/dashboard")} variant="outline">
+            Volver al panel
+          </Button>
+          <Button onClick={handleSignOut}>
+            Cerrar sesión
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -6,7 +6,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { signInWithEmailAndPassword } from "firebase/auth";
-import { useAuth } from "@/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { useAuth, useFirestore } from "@/firebase";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -27,11 +28,10 @@ const formSchema = z.object({
   password: z.string().min(1, "La contraseña es obligatoria."),
 });
 
-const ADMIN_EMAIL = "sanmartinfrancisco8@gmail.com";
-
 export function LoginForm() {
   const router = useRouter();
   const auth = useAuth();
+  const firestore = useFirestore();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -46,14 +46,41 @@ export function LoginForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     try {
-      await signInWithEmailAndPassword(auth, values.email, values.password);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        values.email,
+        values.password,
+      );
+
+      const userDoc = await getDoc(doc(firestore, "users", userCredential.user.uid));
+
+      if (!userDoc.exists()) {
+        await auth.signOut();
+        toast({
+          variant: "destructive",
+          title: "Cuenta no encontrada",
+          description: "No se pudo encontrar la información de tu cuenta. Por favor, contacta al administrador.",
+        });
+        return;
+      }
+
+      const userData = userDoc.data() as { approved?: boolean; role?: string };
+
+      if (!userData?.approved) {
+        toast({
+          title: "Cuenta pendiente de aprobación",
+          description: "Un administrador revisará tu solicitud. Te notificaremos cuando tu cuenta esté activa.",
+        });
+        router.push("/pending-approval");
+        return;
+      }
+
       toast({
         title: "Inicio de sesión exitoso",
         description: "Bienvenido a SAP Intelligent Agent.",
       });
 
-      // Redirect admin to admin page, others to dashboard
-      if (values.email === ADMIN_EMAIL) {
+      if (userData.role === "admin") {
         router.push("/dashboard/admin");
       } else {
         router.push("/dashboard");


### PR DESCRIPTION
## Summary
- verify user approval status from Firestore during login and route admins based on their stored role
- gate the dashboard layout on approved user profiles and redirect pending accounts to a dedicated holding page
- add a pending approval screen with messaging and sign-out controls for users awaiting authorization

## Testing
- not run (npm run lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e698ba83908326b24ce4f84d154edc