### PR TITLE
Fix admin login and surface pending approvals

### DIFF
--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,3 +1,4 @@
+import { PendingApprovalsCard } from "@/components/admin/PendingApprovalsCard";
 import { UserManagementTable } from "@/components/admin/UserManagementTable";
 
 export default function AdminPage() {
@@ -9,6 +10,7 @@ export default function AdminPage() {
           Aprueba, rechaza y gestiona los roles de los usuarios de la aplicación.
         </p>
       </header>
+      <PendingApprovalsCard />
       <UserManagementTable />
     </div>
   );

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -1,4 +1,5 @@
 import { PendingApprovalsCard } from "@/components/admin/PendingApprovalsCard";
+import { PendingRequestsList } from "@/components/admin/PendingRequestsList";
 import { UserManagementTable } from "@/components/admin/UserManagementTable";
 
 export default function AdminPage() {
@@ -11,6 +12,7 @@ export default function AdminPage() {
         </p>
       </header>
       <PendingApprovalsCard />
+      <PendingRequestsList />
       <UserManagementTable />
     </div>
   );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { useUser } from "@/firebase";
+import { useFirestore, useUser } from "@/firebase";
+import { useDoc } from "@/firebase/firestore/use-doc";
 import {
   SidebarProvider,
   Sidebar,
@@ -10,6 +11,12 @@ import {
 import { AppSidebar } from "@/components/layout/AppSidebar";
 import { Header } from "@/components/layout/Header";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { doc } from "firebase/firestore";
+
+type UserProfile = {
+  approved?: boolean;
+  role?: "admin" | "user" | "pending";
+};
 
 export default function DashboardLayout({
   children,
@@ -19,6 +26,14 @@ export default function DashboardLayout({
   const router = useRouter();
   const pathname = usePathname();
   const { user, isUserLoading } = useUser();
+  const firestore = useFirestore();
+
+  const userDocRef = useMemo(
+    () => (user ? doc(firestore, "users", user.uid) : null),
+    [firestore, user],
+  );
+
+  const { data: userProfile, isLoading: isProfileLoading } = useDoc<UserProfile>(userDocRef);
 
   useEffect(() => {
     if (!isUserLoading && !user) {
@@ -26,17 +41,34 @@ export default function DashboardLayout({
     }
   }, [user, isUserLoading, router]);
 
+  useEffect(() => {
+    if (!isUserLoading && user && !isProfileLoading) {
+      if (!userProfile) {
+        router.replace("/login");
+        return;
+      }
+
+      if (!userProfile.approved) {
+        router.replace("/pending-approval");
+      }
+    }
+  }, [isUserLoading, user, isProfileLoading, userProfile, router]);
+
   // Exclude the main dashboard layout from the fullscreen knowledge toolkit pages
   if (pathname.startsWith('/dashboard/knowledge-toolkit')) {
     return <>{children}</>;
   }
-  
-  if (isUserLoading || !user) {
+
+  if (isUserLoading || isProfileLoading || !user || !userProfile) {
     return (
       <div className="flex h-screen w-full items-center justify-center bg-background">
         <LoadingSpinner size={48} />
       </div>
     );
+  }
+
+  if (!userProfile.approved) {
+    return null;
   }
 
   return (

--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/firebase";
+
+export default function PendingApprovalPage() {
+  const auth = useAuth();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await auth.signOut();
+    router.push("/login");
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background via-background to-muted px-4 text-center">
+      <div className="max-w-lg space-y-6 rounded-xl border border-border bg-card/70 p-8 shadow-lg backdrop-blur">
+        <h1 className="font-headline text-3xl font-bold text-primary">Cuenta pendiente de aprobación</h1>
+        <p className="text-muted-foreground">
+          Gracias por registrarte en <span className="font-semibold text-foreground">SAP Intelligent Agent</span>. Tu cuenta se encuentra en proceso de revisión.
+          Recibirás acceso en cuanto un administrador autorice tu solicitud.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Si necesitas acceso urgente, comunícate con tu administrador e indícale el correo con el que te registraste.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-center">
+          <Button onClick={() => router.push("/dashboard")} variant="outline">
+            Volver al panel
+          </Button>
+          <Button onClick={handleSignOut}>
+            Cerrar sesión
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/PendingApprovalsCard.tsx
+++ b/src/components/admin/PendingApprovalsCard.tsx
@@ -33,12 +33,20 @@ export function PendingApprovalsCard() {
 
   const { data: pendingUsers, isLoading } = useCollection<PendingUserData>(pendingUsersQuery);
 
+  const safePendingUsers: PendingUser[] = (pendingUsers ?? []) as PendingUser[];
+  const totalPending = safePendingUsers.length;
+
+  const recentPendingUsers = safePendingUsers
+    .slice()
+    .sort((a, b) => getCreatedAtMillis(b.createdAt) - getCreatedAtMillis(a.createdAt))
+    .slice(0, 5);
+
   return (
     <Card className="border-primary/20 bg-card/60 backdrop-blur">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="font-headline text-xl">Solicitudes pendientes</CardTitle>
-        <Badge variant={pendingUsers && pendingUsers.length > 0 ? "default" : "secondary"}>
-          {pendingUsers?.length ?? 0}
+        <Badge variant={totalPending > 0 ? "default" : "secondary"}>
+          {totalPending}
         </Badge>
       </CardHeader>
       <CardContent>
@@ -46,26 +54,23 @@ export function PendingApprovalsCard() {
           <div className="flex items-center justify-center py-6">
             <LoadingSpinner size={24} />
           </div>
-        ) : !pendingUsers || pendingUsers.length === 0 ? (
+        ) : totalPending === 0 ? (
           <p className="text-sm text-muted-foreground">
             No hay solicitudes de aprobación en espera.
           </p>
         ) : (
           <ul className="space-y-3">
-            {[...(((pendingUsers ?? []) as PendingUser[]))]
-              .sort((a, b) => getCreatedAtMillis(b.createdAt) - getCreatedAtMillis(a.createdAt))
-              .slice(0, 5)
-              .map((user) => (
-                <li key={user.id} className="rounded-md border border-border/60 bg-background/60 p-3">
-                  <p className="font-medium text-foreground">
-                    {user.displayName ?? user.email ?? "Usuario"}
-                  </p>
-                  {user.email ? (
-                    <p className="text-sm text-muted-foreground">{user.email}</p>
-                  ) : null}
-                </li>
-              ))}
-            {pendingUsers && pendingUsers.length > 5 ? (
+            {recentPendingUsers.map((user) => (
+              <li key={user.id} className="rounded-md border border-border/60 bg-background/60 p-3">
+                <p className="font-medium text-foreground">
+                  {user.displayName ?? user.email ?? "Usuario"}
+                </p>
+                {user.email ? (
+                  <p className="text-sm text-muted-foreground">{user.email}</p>
+                ) : null}
+              </li>
+            ))}
+            {totalPending > 5 ? (
               <p className="text-xs text-muted-foreground">
                 Mostrando los 5 registros más recientes. Consulta la tabla completa para más detalles.
               </p>

--- a/src/components/admin/PendingApprovalsCard.tsx
+++ b/src/components/admin/PendingApprovalsCard.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { collection, query, where } from "firebase/firestore";
+import { useMemoFirebase } from "@/firebase/provider";
+import { useFirestore } from "@/firebase";
+import { useCollection } from "@/firebase/firestore/use-collection";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { LoadingSpinner } from "@/components/loading-spinner";
+
+interface PendingUser {
+  displayName?: string;
+  email?: string;
+  createdAt?: { seconds: number; nanoseconds: number };
+}
+
+export function PendingApprovalsCard() {
+  const firestore = useFirestore();
+
+  const pendingUsersQuery = useMemoFirebase(
+    () =>
+      firestore
+        ? query(collection(firestore, "users"), where("approved", "==", false))
+        : null,
+    [firestore],
+  );
+
+  const { data: pendingUsers, isLoading } = useCollection<PendingUser>(pendingUsersQuery);
+
+  return (
+    <Card className="border-primary/20 bg-card/60 backdrop-blur">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="font-headline text-xl">Solicitudes pendientes</CardTitle>
+        <Badge variant={pendingUsers && pendingUsers.length > 0 ? "default" : "secondary"}>
+          {pendingUsers?.length ?? 0}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-6">
+            <LoadingSpinner size={24} />
+          </div>
+        ) : !pendingUsers || pendingUsers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No hay solicitudes de aprobación en espera.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {[...(pendingUsers ?? [])]
+              .sort((a, b) => {
+                const aTime = a.createdAt?.seconds ?? 0;
+                const bTime = b.createdAt?.seconds ?? 0;
+                return bTime - aTime;
+              })
+              .slice(0, 5)
+              .map((user) => (
+                <li key={user.id} className="rounded-md border border-border/60 bg-background/60 p-3">
+                  <p className="font-medium text-foreground">{user.displayName ?? user.email ?? "Usuario"}</p>
+                  {user.email ? (
+                    <p className="text-sm text-muted-foreground">{user.email}</p>
+                  ) : null}
+                </li>
+              ))}
+            {pendingUsers.length > 5 ? (
+              <p className="text-xs text-muted-foreground">
+                Mostrando los 5 registros más recientes. Consulta la tabla completa para más detalles.
+              </p>
+            ) : null}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/PendingApprovalsCard.tsx
+++ b/src/components/admin/PendingApprovalsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { collection, query, where } from "firebase/firestore";
+import { collection, query, where, Timestamp } from "firebase/firestore";
 import { useMemoFirebase } from "@/firebase/provider";
 import { useFirestore } from "@/firebase";
 import { useCollection } from "@/firebase/firestore/use-collection";
@@ -8,10 +8,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { LoadingSpinner } from "@/components/loading-spinner";
 
-interface PendingUser {
+interface PendingUserData {
   displayName?: string;
   email?: string;
-  createdAt?: { seconds: number; nanoseconds: number };
+  createdAt?: Timestamp;
+}
+
+type PendingUser = PendingUserData & { id: string };
+
+function getCreatedAtMillis(createdAt?: Timestamp) {
+  return createdAt?.toMillis() ?? 0;
 }
 
 export function PendingApprovalsCard() {
@@ -25,7 +31,7 @@ export function PendingApprovalsCard() {
     [firestore],
   );
 
-  const { data: pendingUsers, isLoading } = useCollection<PendingUser>(pendingUsersQuery);
+  const { data: pendingUsers, isLoading } = useCollection<PendingUserData>(pendingUsersQuery);
 
   return (
     <Card className="border-primary/20 bg-card/60 backdrop-blur">
@@ -46,22 +52,20 @@ export function PendingApprovalsCard() {
           </p>
         ) : (
           <ul className="space-y-3">
-            {[...(pendingUsers ?? [])]
-              .sort((a, b) => {
-                const aTime = a.createdAt?.seconds ?? 0;
-                const bTime = b.createdAt?.seconds ?? 0;
-                return bTime - aTime;
-              })
+            {[...(((pendingUsers ?? []) as PendingUser[]))]
+              .sort((a, b) => getCreatedAtMillis(b.createdAt) - getCreatedAtMillis(a.createdAt))
               .slice(0, 5)
               .map((user) => (
                 <li key={user.id} className="rounded-md border border-border/60 bg-background/60 p-3">
-                  <p className="font-medium text-foreground">{user.displayName ?? user.email ?? "Usuario"}</p>
+                  <p className="font-medium text-foreground">
+                    {user.displayName ?? user.email ?? "Usuario"}
+                  </p>
                   {user.email ? (
                     <p className="text-sm text-muted-foreground">{user.email}</p>
                   ) : null}
                 </li>
               ))}
-            {pendingUsers.length > 5 ? (
+            {pendingUsers && pendingUsers.length > 5 ? (
               <p className="text-xs text-muted-foreground">
                 Mostrando los 5 registros más recientes. Consulta la tabla completa para más detalles.
               </p>

--- a/src/components/admin/PendingRequestsList.tsx
+++ b/src/components/admin/PendingRequestsList.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import {
+  collection,
+  doc,
+  query,
+  serverTimestamp,
+  Timestamp,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import { useFirestore, useUser } from "@/firebase";
+import { useMemoFirebase } from "@/firebase/provider";
+import { useCollection } from "@/firebase/firestore/use-collection";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { LoadingSpinner } from "@/components/loading-spinner";
+import { format } from "date-fns";
+import { useToast } from "@/hooks/use-toast";
+
+interface PendingUserData {
+  displayName?: string;
+  email?: string;
+  createdAt?: Timestamp;
+}
+
+type PendingUser = PendingUserData & { id: string };
+
+function formatCreatedAt(createdAt?: Timestamp) {
+  return createdAt ? format(createdAt.toDate(), "dd/MM/yyyy HH:mm") : "Sin fecha";
+}
+
+export function PendingRequestsList() {
+  const firestore = useFirestore();
+  const { user: adminUser } = useUser();
+  const { toast } = useToast();
+  const [updatingUserId, setUpdatingUserId] = useState<string | null>(null);
+
+  const pendingUsersQuery = useMemoFirebase(
+    () =>
+      firestore
+        ? query(collection(firestore, "users"), where("approved", "==", false))
+        : null,
+    [firestore],
+  );
+
+  const { data: pendingUsers, isLoading } = useCollection<PendingUserData>(pendingUsersQuery);
+
+  const handleApproveUser = async (user: PendingUser) => {
+    if (!firestore || !adminUser) return;
+
+    setUpdatingUserId(user.id);
+    try {
+      await updateDoc(doc(firestore, "users", user.id), {
+        approved: true,
+        role: "user",
+        updatedAt: serverTimestamp(),
+      });
+
+      toast({
+        title: "Usuario aprobado",
+        description: `${user.displayName ?? user.email ?? "El usuario"} ahora puede acceder al panel.`,
+      });
+    } catch (error) {
+      console.error("Error approving user:", error);
+      toast({
+        variant: "destructive",
+        title: "No se pudo aprobar",
+        description: "Ocurrió un problema al actualizar la solicitud. Inténtalo nuevamente.",
+      });
+    } finally {
+      setUpdatingUserId(null);
+    }
+  };
+
+  return (
+    <Card className="border-primary/20 bg-card/60 backdrop-blur">
+      <CardHeader>
+        <CardTitle className="font-headline text-xl">Solicitudes en espera</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading || !adminUser ? (
+          <div className="flex items-center justify-center py-6">
+            <LoadingSpinner size={24} />
+          </div>
+        ) : !pendingUsers || pendingUsers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            En este momento no hay cuentas pendientes de aprobación.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {((pendingUsers ?? []) as PendingUser[])
+              .slice()
+              .sort((a, b) => {
+                const aTime = a.createdAt?.toMillis() ?? 0;
+                const bTime = b.createdAt?.toMillis() ?? 0;
+                return bTime - aTime;
+              })
+              .map((user) => (
+                <li
+                  key={user.id}
+                  className="flex flex-col gap-2 rounded-md border border-border/60 bg-background/60 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <p className="font-medium text-foreground">
+                      {user.displayName ?? user.email ?? "Usuario"}
+                    </p>
+                    <div className="text-sm text-muted-foreground">
+                      {user.email ?? "Sin correo registrado"}
+                      <span className="mx-2 inline-block h-1 w-1 rounded-full bg-muted-foreground align-middle" />
+                      {formatCreatedAt(user.createdAt)}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    disabled={updatingUserId === user.id}
+                    onClick={() => handleApproveUser(user)}
+                  >
+                    {updatingUserId === user.id ? <LoadingSpinner size={16} /> : "Aprobar"}
+                  </Button>
+                </li>
+              ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/components/admin/PendingRequestsList.tsx
+++ b/src/components/admin/PendingRequestsList.tsx
@@ -47,6 +47,15 @@ export function PendingRequestsList() {
 
   const { data: pendingUsers, isLoading } = useCollection<PendingUserData>(pendingUsersQuery);
 
+  const safePendingUsers: PendingUser[] = (pendingUsers ?? []) as PendingUser[];
+  const sortedPendingUsers = safePendingUsers
+    .slice()
+    .sort((a, b) => {
+      const aTime = a.createdAt?.toMillis() ?? 0;
+      const bTime = b.createdAt?.toMillis() ?? 0;
+      return bTime - aTime;
+    });
+
   const handleApproveUser = async (user: PendingUser) => {
     if (!firestore || !adminUser) return;
 
@@ -84,43 +93,36 @@ export function PendingRequestsList() {
           <div className="flex items-center justify-center py-6">
             <LoadingSpinner size={24} />
           </div>
-        ) : !pendingUsers || pendingUsers.length === 0 ? (
+        ) : sortedPendingUsers.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             En este momento no hay cuentas pendientes de aprobación.
           </p>
         ) : (
           <ul className="space-y-3">
-            {((pendingUsers ?? []) as PendingUser[])
-              .slice()
-              .sort((a, b) => {
-                const aTime = a.createdAt?.toMillis() ?? 0;
-                const bTime = b.createdAt?.toMillis() ?? 0;
-                return bTime - aTime;
-              })
-              .map((user) => (
-                <li
-                  key={user.id}
-                  className="flex flex-col gap-2 rounded-md border border-border/60 bg-background/60 p-3 sm:flex-row sm:items-center sm:justify-between"
-                >
-                  <div>
-                    <p className="font-medium text-foreground">
-                      {user.displayName ?? user.email ?? "Usuario"}
-                    </p>
-                    <div className="text-sm text-muted-foreground">
-                      {user.email ?? "Sin correo registrado"}
-                      <span className="mx-2 inline-block h-1 w-1 rounded-full bg-muted-foreground align-middle" />
-                      {formatCreatedAt(user.createdAt)}
-                    </div>
+            {sortedPendingUsers.map((user) => (
+              <li
+                key={user.id}
+                className="flex flex-col gap-2 rounded-md border border-border/60 bg-background/60 p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <p className="font-medium text-foreground">
+                    {user.displayName ?? user.email ?? "Usuario"}
+                  </p>
+                  <div className="text-sm text-muted-foreground">
+                    {user.email ?? "Sin correo registrado"}
+                    <span className="mx-2 inline-block h-1 w-1 rounded-full bg-muted-foreground align-middle" />
+                    {formatCreatedAt(user.createdAt)}
                   </div>
-                  <Button
-                    size="sm"
-                    disabled={updatingUserId === user.id}
-                    onClick={() => handleApproveUser(user)}
-                  >
-                    {updatingUserId === user.id ? <LoadingSpinner size={16} /> : "Aprobar"}
-                  </Button>
-                </li>
-              ))}
+                </div>
+                <Button
+                  size="sm"
+                  disabled={updatingUserId === user.id}
+                  onClick={() => handleApproveUser(user)}
+                >
+                  {updatingUserId === user.id ? <LoadingSpinner size={16} /> : "Aprobar"}
+                </Button>
+              </li>
+            ))}
           </ul>
         )}
       </CardContent>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -98,8 +98,8 @@ export function LoginForm() {
 
       const userDocRef = doc(firestore, "users", userCredential.user.uid);
       const userDoc = await getDoc(userDocRef);
-      const email =
-        userCredential.user.email?.toLowerCase() ?? normalizedEmail;
+      const canonicalEmail = userCredential.user.email?.trim() ?? trimmedEmail;
+      const email = canonicalEmail.toLowerCase();
       const isAdminEmail = ADMIN_EMAILS.has(email);
 
       let userData = userDoc.data() as UserProfile | undefined;
@@ -109,9 +109,9 @@ export function LoginForm() {
           uid: userCredential.user.uid,
           displayName:
             userCredential.user.displayName ||
-            userCredential.user.email?.split("@")[0] ||
-            values.email,
-          email: userCredential.user.email ?? values.email,
+            canonicalEmail.split("@")[0] ||
+            trimmedEmail,
+          email: canonicalEmail,
           role: isAdminEmail ? "admin" : "pending",
           approved: isAdminEmail,
           createdAt: serverTimestamp(),

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -5,7 +5,11 @@ import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
-import { signInWithEmailAndPassword } from "firebase/auth";
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+} from "firebase/auth";
+import type { UserCredential } from "firebase/auth";
 import {
   doc,
   getDoc,
@@ -61,15 +65,41 @@ export function LoginForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     try {
-      const userCredential = await signInWithEmailAndPassword(
-        auth,
-        values.email,
-        values.password,
-      );
+      const trimmedEmail = values.email.trim();
+      const normalizedEmail = trimmedEmail.toLowerCase();
+      const password = values.password;
+      const isKnownAdminEmail = ADMIN_EMAILS.has(normalizedEmail);
+
+      let userCredential: UserCredential;
+
+      try {
+        userCredential = await signInWithEmailAndPassword(
+          auth,
+          trimmedEmail,
+          password,
+        );
+      } catch (authError: any) {
+        const errorCode = authError?.code as string | undefined;
+        const isMissingAccount =
+          errorCode === "auth/user-not-found" ||
+          errorCode === "auth/invalid-credential" ||
+          errorCode === "auth/invalid-login-credentials";
+
+        if (isKnownAdminEmail && isMissingAccount) {
+          userCredential = await createUserWithEmailAndPassword(
+            auth,
+            trimmedEmail,
+            password,
+          );
+        } else {
+          throw authError;
+        }
+      }
 
       const userDocRef = doc(firestore, "users", userCredential.user.uid);
       const userDoc = await getDoc(userDocRef);
-      const email = userCredential.user.email?.toLowerCase() ?? values.email.toLowerCase();
+      const email =
+        userCredential.user.email?.toLowerCase() ?? normalizedEmail;
       const isAdminEmail = ADMIN_EMAILS.has(email);
 
       let userData = userDoc.data() as UserProfile | undefined;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -6,7 +6,14 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { signInWithEmailAndPassword } from "firebase/auth";
-import { useAuth } from "@/firebase";
+import {
+  doc,
+  getDoc,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from "firebase/firestore";
+import { useAuth, useFirestore } from "@/firebase";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -22,16 +29,24 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { LoadingSpinner } from "@/components/loading-spinner";
 
+const ADMIN_EMAILS = new Set([
+  "sanmartinfrancisco8@gmail.com",
+]);
+
+type UserProfile = {
+  approved?: boolean;
+  role?: "admin" | "user" | "pending";
+};
+
 const formSchema = z.object({
   email: z.string().email("Por favor, introduce un email válido."),
   password: z.string().min(1, "La contraseña es obligatoria."),
 });
 
-const ADMIN_EMAIL = "sanmartinfrancisco8@gmail.com";
-
 export function LoginForm() {
   const router = useRouter();
   const auth = useAuth();
+  const firestore = useFirestore();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -46,14 +61,93 @@ export function LoginForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     try {
-      await signInWithEmailAndPassword(auth, values.email, values.password);
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        values.email,
+        values.password,
+      );
+
+      const userDocRef = doc(firestore, "users", userCredential.user.uid);
+      const userDoc = await getDoc(userDocRef);
+      const email = userCredential.user.email?.toLowerCase() ?? values.email.toLowerCase();
+      const isAdminEmail = ADMIN_EMAILS.has(email);
+
+      let userData = userDoc.data() as UserProfile | undefined;
+
+      if (!userDoc.exists()) {
+        const defaultProfile = {
+          uid: userCredential.user.uid,
+          displayName:
+            userCredential.user.displayName ||
+            userCredential.user.email?.split("@")[0] ||
+            values.email,
+          email: userCredential.user.email ?? values.email,
+          role: isAdminEmail ? "admin" : "pending",
+          approved: isAdminEmail,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        };
+
+        await setDoc(userDocRef, defaultProfile);
+        userData = { approved: defaultProfile.approved, role: defaultProfile.role };
+      }
+
+      if (userData) {
+        const updates: Partial<UserProfile> = {};
+
+        if (isAdminEmail && userData.role !== "admin") {
+          updates.role = "admin";
+        }
+
+        if (isAdminEmail && userData.approved !== true) {
+          updates.approved = true;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          await updateDoc(userDocRef, {
+            ...updates,
+            updatedAt: serverTimestamp(),
+          });
+          userData = { ...userData, ...updates };
+        }
+      }
+
+      if (!userData) {
+        await auth.signOut();
+        toast({
+          variant: "destructive",
+          title: "Cuenta no encontrada",
+          description: "No se pudo encontrar la información de tu cuenta. Por favor, contacta al administrador.",
+        });
+        return;
+      }
+
+      const normalizedUserData = {
+        approved: userData.approved ?? false,
+        role:
+          userData.role ??
+          (userData.approved
+            ? "user"
+            : isAdminEmail
+              ? "admin"
+              : "pending"),
+      };
+
+      if (!normalizedUserData.approved) {
+        toast({
+          title: "Cuenta pendiente de aprobación",
+          description: "Un administrador revisará tu solicitud. Te notificaremos cuando tu cuenta esté activa.",
+        });
+        router.push("/pending-approval");
+        return;
+      }
+
       toast({
         title: "Inicio de sesión exitoso",
         description: "Bienvenido a SAP Intelligent Agent.",
       });
 
-      // Redirect admin to admin page, others to dashboard
-      if (values.email === ADMIN_EMAIL) {
+      if (normalizedUserData.role === "admin") {
         router.push("/dashboard/admin");
       } else {
         router.push("/dashboard");


### PR DESCRIPTION
## Summary
- verify user approval status from Firestore during login, auto-provision known admin accounts when missing, and route admins based on their stored role
- gate the dashboard layout on approved user profiles and redirect pending accounts to a dedicated holding page
- add a pending approval screen with messaging and sign-out controls for users awaiting authorization
- surface a pending approvals summary card so administrators can quickly see whether there are requests to review

## Testing
- not run (npm run lint prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e698ba83908326b24ce4f84d154edc