### PR TITLE
Fix admin setup to persist Firestore profile

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,7 +4,8 @@ import { generateModuleSummary, type ModuleSummaryInput } from "@/ai/flows/gener
 import { generateMindMap, type GenerateMindMapInput } from "@/ai/flows/generate-mind-map";
 import { generateProcessFlow, type GenerateProcessFlowInput } from "@/ai/flows/generate-process-flow";
 import { aiChatAssistant, type AIChatAssistantInput } from "@/ai/flows/ai-chat-assistant";
-import { adminAuth } from "@/firebase/admin";
+import { adminAuth, adminDb } from "@/firebase/admin";
+import { FieldValue } from "firebase-admin/firestore";
 
 export async function getModuleSummary(input: ModuleSummaryInput) {
   const result = await generateModuleSummary(input);
@@ -26,36 +27,75 @@ export async function getChatResponse(input: AIChatAssistantInput) {
   return result.answer;
 }
 
-async function createAdminUser(email: string, password_hash: string) {
-    const userRecord = await adminAuth.createUser({
-        email,
-        password: password_hash,
+async function createAdminUser(email: string, password: string, displayName: string) {
+  const userRecord = await adminAuth.createUser({
+    email,
+    password,
+    displayName,
+  });
+
+  await adminAuth.setCustomUserClaims(userRecord.uid, { admin: true });
+
+  await adminDb
+    .collection('users')
+    .doc(userRecord.uid)
+    .set({
+      uid: userRecord.uid,
+      displayName,
+      email: userRecord.email ?? email,
+      role: 'admin',
+      approved: true,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     });
 
-    await adminAuth.setCustomUserClaims(userRecord.uid, { admin: true });
-
-    return {
-        uid: userRecord.uid,
-        email: userRecord.email,
-    }
+  return {
+    uid: userRecord.uid,
+    email: userRecord.email ?? email,
+  };
 }
 
 export async function setupInitialAdmin() {
-    const email = "sanmartinfrancisco8@gmail.com";
-    const password = "123456";
+  const email = process.env.INITIAL_ADMIN_EMAIL ?? 'sanmartinfrancisco8@gmail.com';
+  const password = process.env.INITIAL_ADMIN_PASSWORD ?? '123456';
+  const displayName = process.env.INITIAL_ADMIN_NAME ?? 'Administrador';
 
-    try {
-        const user = await adminAuth.getUserByEmail(email).catch(() => null);
-        if (user) {
-            if (!user.customClaims?.admin) {
-                 await adminAuth.setCustomUserClaims(user.uid, { admin: true });
-            }
-            return { message: "Admin user already exists." };
+  try {
+    const user = await adminAuth.getUserByEmail(email).catch(() => null);
+    if (user) {
+      if (!user.customClaims?.admin) {
+        await adminAuth.setCustomUserClaims(user.uid, { admin: true });
+      }
+
+      const userDocRef = adminDb.collection('users').doc(user.uid);
+      const userDoc = await userDocRef.get();
+      if (!userDoc.exists) {
+        await userDocRef.set({
+          uid: user.uid,
+          displayName: user.displayName ?? displayName,
+          email: user.email ?? email,
+          role: 'admin',
+          approved: true,
+          createdAt: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+      } else {
+        const data = userDoc.data() ?? {};
+        if (data.role !== 'admin' || data.approved !== true) {
+          await userDocRef.update({
+            role: 'admin',
+            approved: true,
+            updatedAt: FieldValue.serverTimestamp(),
+          });
         }
+      }
 
-        const newUser = await createAdminUser(email, password);
-        return { message: "Admin user created successfully.", user: newUser };
-    } catch (error: any) {
-        return { error: `Failed to set up admin user: ${error.message}` };
+      return { message: 'Admin user already exists.' };
     }
+
+    const newUser = await createAdminUser(email, password, displayName);
+    return { message: 'Admin user created successfully.', user: newUser };
+  } catch (error: any) {
+    return { error: `Failed to set up admin user: ${error.message}` };
+  }
 }

--- a/src/firebase/admin.ts
+++ b/src/firebase/admin.ts
@@ -1,5 +1,6 @@
 import { initializeApp, getApps, App } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
 
 function initializeAdminApp(): App {
   const apps = getApps();
@@ -14,3 +15,4 @@ function initializeAdminApp(): App {
 
 const adminApp = initializeAdminApp();
 export const adminAuth = getAuth(adminApp);
+export const adminDb = getFirestore(adminApp);


### PR DESCRIPTION
## Summary
- export the Firebase Admin Firestore instance so server actions can write user metadata
- extend the admin bootstrap action to persist an approved admin document and repair missing data on existing accounts
- allow configuration of the initial admin credentials through environment variables

## Testing
- ⚠️ `npm run lint` *(cannot run because the command prompts for ESLint configuration interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea43a8d83083269f9e2daf628fdd66