### PR TITLE
Enable static export build for Hostinger

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -9,32 +9,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'placehold.co',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'images.unsplash.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'picsum.photos',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'i.imgur.com',
-        port: '',
-        pathname: '/**',
-      }
-    ],
+    unoptimized: true,
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "NODE_ENV=production next build",
     "start": "next start",
+    "export": "node scripts/export.mjs",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -1,0 +1,30 @@
+import {cp, rm, stat} from 'fs/promises';
+import path from 'path';
+
+const cwd = process.cwd();
+const source = path.join(cwd, '.next', 'export');
+const destination = path.join(cwd, 'out');
+
+async function ensureSourceExists() {
+  try {
+    const stats = await stat(source);
+    if (!stats.isDirectory()) {
+      throw new Error('The export source exists but is not a directory.');
+    }
+  } catch (error) {
+    throw new Error(
+      "Static export artifacts were not found. Run 'npm run build' before exporting."
+    );
+  }
+}
+
+async function main() {
+    await ensureSourceExists();
+    await rm(destination, {recursive: true, force: true});
+    await cp(source, destination, {recursive: true});
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- configure Next.js to emit a static export bundle and disable image optimization for Hostinger
- add an npm export script that copies the generated static artifacts into the out/ directory expected by the host

## Testing
- npm run build
- npm run export

------
https://chatgpt.com/codex/tasks/task_e_68ec2b3a1ea4832687ed53fd5251e535