### PR TITLE
Configure Hostinger-friendly deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Variables de entorno para el SDK web de Firebase
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+# Opcional para Google Analytics
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+# Configuración del SDK de administrador (elige una de las opciones)
+# Opción 1: variables desglosadas
+FIREBASE_ADMIN_PROJECT_ID=
+FIREBASE_ADMIN_CLIENT_EMAIL=
+FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+
+# Opción 2: JSON completo de la service account
+FIREBASE_ADMIN_SERVICE_ACCOUNT=
+
+# Opción 3: JSON codificado en Base64
+FIREBASE_ADMIN_SERVICE_ACCOUNT_BASE64=
+
+# Credenciales iniciales del usuario administrador
+INITIAL_ADMIN_EMAIL=
+INITIAL_ADMIN_PASSWORD=
+INITIAL_ADMIN_NAME=

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,71 @@
 # Firebase Studio
 
-This is a NextJS starter in Firebase Studio.
+Este proyecto es una aplicación Next.js que integra Firebase para autenticación y Firestore, además de flujos de IA. El repositorio se ha actualizado para facilitar el despliegue en servicios como Hostinger, donde la aplicación se ejecuta como un servidor Node.js tradicional.
 
-To get started, take a look at src/app/page.tsx.
+## Requisitos previos
+
+- Node.js 18.17 o superior (Hostinger soporta esta versión en sus planes de hosting con Node).
+- Una cuenta de Firebase con un proyecto configurado y un servicio de cuenta (service account) con permisos de administrador.
+- Variables de entorno configuradas para el cliente (SDK web) y para el administrador (Firebase Admin SDK).
+
+## Variables de entorno
+
+Crea un archivo `.env.local` para desarrollo y `.env.production` para el despliegue en Hostinger. Utiliza el archivo [`\.env.example`](./.env.example) como referencia.
+
+Variables de entorno para el SDK de cliente (deben comenzar con `NEXT_PUBLIC_` para que Next.js las exponga en el navegador):
+
+```env
+NEXT_PUBLIC_FIREBASE_API_KEY=""
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=""
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=""
+NEXT_PUBLIC_FIREBASE_APP_ID=""
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=""
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID="" # opcional
+```
+
+Variables de entorno para el SDK de administrador (se utilizan en las Server Actions y rutas protegidas):
+
+```env
+# Opción 1: variables desglosadas
+FIREBASE_ADMIN_PROJECT_ID=""
+FIREBASE_ADMIN_CLIENT_EMAIL=""
+FIREBASE_ADMIN_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+
+# Opción 2: JSON completo
+FIREBASE_ADMIN_SERVICE_ACCOUNT='{"project_id":"","client_email":"","private_key":"-----BEGIN PRIVATE KEY-----\n..."}'
+
+# Opción 3: JSON codificado en Base64
+FIREBASE_ADMIN_SERVICE_ACCOUNT_BASE64=""
+
+# Credenciales iniciales del administrador creadas por la acción setupInitialAdmin
+INITIAL_ADMIN_EMAIL="admin@tudominio.com"
+INITIAL_ADMIN_PASSWORD="contraseña-segura"
+INITIAL_ADMIN_NAME="Nombre del Admin"
+```
+
+> El código detecta automáticamente la opción disponible en el orden Base64 → JSON → variables desglosadas. Asegúrate de definir al menos una de ellas en Hostinger.
+
+## Scripts disponibles
+
+- `npm run dev`: Ejecuta el servidor de desarrollo en el puerto 9002.
+- `npm run build`: Genera el build de producción.
+- `npm run start`: Arranca el servidor de producción (`next start`) respetando la variable `PORT` que define Hostinger.
+
+## Despliegue en Hostinger
+
+1. **Conecta tu repositorio de GitHub** desde el panel de Hostinger y selecciona la rama que deseas desplegar.
+2. Configura las variables de entorno en el apartado de *Environment Variables* del panel, copiando los valores descritos anteriormente.
+3. Establece los comandos de *Build* y *Start*:
+   - Build: `npm install && npm run build`
+   - Start: `npm run start`
+4. Guarda la configuración y ejecuta el despliegue. Hostinger instalará dependencias, construirá la aplicación y levantará el servidor Next.js.
+
+> Gracias a la nueva configuración, ya no es necesario depender de las credenciales automáticas de Firebase Hosting. El despliegue funciona en cualquier plataforma Node.js que permita definir variables de entorno.
+
+## Desarrollo local
+
+1. Clona el repositorio y crea el archivo `.env.local` siguiendo el ejemplo proporcionado.
+2. Ejecuta `npm install` para instalar las dependencias.
+3. Inicia el entorno de desarrollo con `npm run dev`.
+
+Para entender el flujo principal de la aplicación comienza explorando `src/app/page.tsx` y los componentes en `src/components`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
-  output: 'export',
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "nextn",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18.17.0",
+    "npm": ">=9.0.0"
+  },
   "scripts": {
     "dev": "next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",

--- a/src/firebase/admin.ts
+++ b/src/firebase/admin.ts
@@ -1,6 +1,77 @@
-import { initializeApp, getApps, App } from 'firebase-admin/app';
+import { initializeApp, getApps, App, cert, applicationDefault } from 'firebase-admin/app';
+import { Buffer } from 'node:buffer';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
+
+type ServiceAccountConfig = {
+  projectId: string;
+  clientEmail: string;
+  privateKey: string;
+};
+
+function normalizeServiceAccountConfig(input: Record<string, unknown> | null | undefined): ServiceAccountConfig | undefined {
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+
+  const projectId = (input['projectId'] ?? input['project_id']) as string | undefined;
+  const clientEmail = (input['clientEmail'] ?? input['client_email']) as string | undefined;
+  const privateKey = (input['privateKey'] ?? input['private_key']) as string | undefined;
+
+  if (!projectId || !clientEmail || !privateKey) {
+    return undefined;
+  }
+
+  return {
+    projectId,
+    clientEmail,
+    privateKey: privateKey.replace(/\\n/g, '\n'),
+  };
+}
+
+function getServiceAccountFromEnv(): ServiceAccountConfig | undefined {
+  const base64ServiceAccount = process.env.FIREBASE_ADMIN_SERVICE_ACCOUNT_BASE64;
+  if (base64ServiceAccount) {
+    try {
+      const decoded = Buffer.from(base64ServiceAccount, 'base64').toString('utf8');
+      const parsed = JSON.parse(decoded) as Record<string, unknown>;
+      const config = normalizeServiceAccountConfig(parsed);
+      if (config) {
+        return config;
+      }
+    } catch (error) {
+      console.warn('No se pudo analizar FIREBASE_ADMIN_SERVICE_ACCOUNT_BASE64. Se intentarán otras opciones.', error);
+    }
+  }
+
+  const jsonServiceAccount = process.env.FIREBASE_ADMIN_SERVICE_ACCOUNT;
+  if (jsonServiceAccount) {
+    try {
+      const parsed = JSON.parse(jsonServiceAccount) as Record<string, unknown>;
+      const config = normalizeServiceAccountConfig(parsed);
+      if (config) {
+        return config;
+      }
+    } catch (error) {
+      console.warn('No se pudo analizar FIREBASE_ADMIN_SERVICE_ACCOUNT. Se intentarán otras opciones.', error);
+    }
+  }
+
+  const projectId =
+    process.env.FIREBASE_ADMIN_PROJECT_ID ?? process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY;
+
+  if (projectId && clientEmail && privateKey) {
+    return {
+      projectId,
+      clientEmail,
+      privateKey: privateKey.replace(/\\n/g, '\n'),
+    };
+  }
+
+  return undefined;
+}
 
 function initializeAdminApp(): App {
   const apps = getApps();
@@ -8,8 +79,34 @@ function initializeAdminApp(): App {
     return apps[0];
   }
 
-  // In a managed environment like App Hosting, initializeApp() with no arguments
-  // will automatically use the available service account credentials.
+  const serviceAccount = getServiceAccountFromEnv();
+
+  if (serviceAccount) {
+    return initializeApp({
+      credential: cert({
+        projectId: serviceAccount.projectId,
+        clientEmail: serviceAccount.clientEmail,
+        privateKey: serviceAccount.privateKey,
+      }),
+      projectId: serviceAccount.projectId,
+    });
+  }
+
+  try {
+    return initializeApp({
+      credential: applicationDefault(),
+      projectId: process.env.FIREBASE_ADMIN_PROJECT_ID ?? process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    });
+  } catch (error) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        'No se encontraron credenciales de servicio para Firebase Admin. ' +
+          'Configura las variables FIREBASE_ADMIN_* para ejecutar acciones administrativas en producción.',
+        error
+      );
+    }
+  }
+
   return initializeApp();
 }
 

--- a/src/firebase/config.ts
+++ b/src/firebase/config.ts
@@ -1,8 +1,68 @@
-export const firebaseConfig = {
-  "projectId": "studio-3193836505-da060",
-  "appId": "1:179665586409:web:d0d3990e9e4e4f8cd40878",
-  "apiKey": "AIzaSyButI8QW6xrzvc9O4J_pPLs3azMmB-I0t0",
-  "authDomain": "studio-3193836505-da060.firebaseapp.com",
-  "measurementId": "",
-  "messagingSenderId": "179665586409"
+type FirebaseClientConfig = {
+  projectId: string;
+  appId: string;
+  apiKey: string;
+  authDomain: string;
+  measurementId: string;
+  messagingSenderId: string;
 };
+
+const fallbackConfig: FirebaseClientConfig = {
+  projectId: 'studio-3193836505-da060',
+  appId: '1:179665586409:web:d0d3990e9e4e4f8cd40878',
+  apiKey: 'AIzaSyButI8QW6xrzvc9O4J_pPLs3azMmB-I0t0',
+  authDomain: 'studio-3193836505-da060.firebaseapp.com',
+  measurementId: '',
+  messagingSenderId: '179665586409',
+};
+
+const requiredEnvVars: Array<keyof FirebaseClientConfig> = [
+  'projectId',
+  'appId',
+  'apiKey',
+  'authDomain',
+  'messagingSenderId',
+];
+
+function getEnvConfig(): Partial<FirebaseClientConfig> {
+  return {
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  } satisfies Partial<FirebaseClientConfig>;
+}
+
+function hasAllRequiredValues(config: Partial<FirebaseClientConfig>): config is FirebaseClientConfig {
+  return requiredEnvVars.every(key => typeof config[key] === 'string' && config[key]);
+}
+
+function buildFirebaseConfig(): FirebaseClientConfig {
+  const envConfig = getEnvConfig();
+
+  if (hasAllRequiredValues(envConfig)) {
+    return {
+      ...envConfig,
+      measurementId: envConfig.measurementId ?? '',
+    };
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    const missing = requiredEnvVars.filter(key => !envConfig[key]);
+    console.warn(
+      `Faltan variables de entorno para la configuración de Firebase (${missing.join(', ')}). ` +
+        'Se utilizará la configuración predeterminada del repositorio. ' +
+        'Configura las variables NEXT_PUBLIC_FIREBASE_* para evitar este mensaje.'
+    );
+  }
+
+  return fallbackConfig;
+}
+
+export const firebaseConfig = buildFirebaseConfig();
+
+export function isUsingFallbackFirebaseConfig() {
+  return firebaseConfig === fallbackConfig;
+}


### PR DESCRIPTION
## Summary
- switch the Next.js configuration back to a Node.js runtime so the app can run on Hostinger
- drive Firebase client and admin setup through environment variables, with fallbacks and documentation
- add a public .env.example template and README guidance for Hostinger deployments

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec2e5112a4832684190d5ccaffda85